### PR TITLE
Update API endpoint and default data source to api mode

### DIFF
--- a/src/contexts/DataSourceContext.tsx
+++ b/src/contexts/DataSourceContext.tsx
@@ -22,9 +22,9 @@ export function DataSourceProvider({
   children: React.ReactNode;
 }) {
   const [dataSource, setDataSourceState] = useState<DataSourceType>(() => {
-    // 从localStorage读取用户之前的选择，默认为mock模式以确保系统可用
+    // 从localStorage读取用户之前的选择，默认为api模式以测试新接口
     const saved = localStorage.getItem(DATA_SOURCE_STORAGE_KEY);
-    return (saved as DataSourceType) || "mock";
+    return (saved as DataSourceType) || "api";
   });
 
   const setDataSource = (source: DataSourceType) => {

--- a/src/hooks/useSystemMetrics.ts
+++ b/src/hooks/useSystemMetrics.ts
@@ -113,7 +113,7 @@ export function useSystemMetrics(options: UseSystemMetricsOptions = {}) {
       // 记录详细错误信息供调试用
       console.error("🔧 API错误详情:", {
         error: error instanceof Error ? error.message : error,
-        apiUrl: "http://l4flhxbv.beesnat.com/api/v1/metrics/",
+        apiUrl: "http://rc56132tg24.vicp.fun/api/v1/metrics/",
         timestamp: new Date().toISOString(),
       });
     } finally {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -37,7 +37,7 @@ export default function Index() {
                 <p className="text-blue-400 text-sm leading-relaxed">
                   系统正在尝试连接到API服务器{" "}
                   <code className="bg-blue-800/30 px-1 rounded text-xs">
-                    http://l4flhxbv.beesnat.com
+                    http://rc56132tg24.vicp.fun
                   </code>
                   。
                   如果显示"连接中..."，这是正常的加载过程。如果连接失败，系统会自动切换到演示模式，

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,13 +6,13 @@
 // API基础配置
 const API_BASE_URL = import.meta.env.DEV
   ? "" // 开发环境使用代理
-  : "http://l4flhxbv.beesnat.com"; // 生产环境直接连接
+  : "http://rc56132tg24.vicp.fun"; // 生产环境直接连接
 
 console.log("🔧 API配置:", {
   isDev: import.meta.env.DEV,
   baseURL: API_BASE_URL || "使用代理",
   fullURL: `${API_BASE_URL}/api/v1/metrics/`,
-  proxyTarget: "http://l4flhxbv.beesnat.com",
+  proxyTarget: "http://rc56132tg24.vicp.fun",
 });
 const API_VERSION = "v1";
 const API_PREFIX = `/api/${API_VERSION}`;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -362,14 +362,14 @@ class HttpClient {
     // In development mode, use relative URLs for proxy
     const url = API_BASE_URL ? `${API_BASE_URL}${endpoint}` : endpoint;
 
-    // Use appropriate timeouts for different endpoints
+    // Use appropriate timeouts for different endpoints - 缩短超时时间以便更快诊断问题
     const timeout =
       customTimeout ||
       (endpoint.includes("/health")
-        ? 8000
+        ? 5000
         : endpoint.includes("/metrics")
-          ? 25000
-          : 15000);
+          ? 10000
+          : 8000);
 
     // 添加更多CORS和网络兼容性选项
     const config: RequestInit = {
@@ -386,12 +386,18 @@ class HttpClient {
       signal: this.createTimeoutSignal(timeout),
     };
 
-    console.log(`API Request: ${options.method || "GET"} ${url}`);
+    console.log(`🚀 API Request: ${options.method || "GET"} ${url}`, config);
 
     try {
       const response = await fetch(url, config);
       console.log(
-        `API Response: ${response.status} ${response.statusText} for ${url}`,
+        `✅ API Response: ${response.status} ${response.statusText} for ${url}`,
+        {
+          headers: Object.fromEntries(response.headers.entries()),
+          ok: response.ok,
+          type: response.type,
+          url: response.url,
+        },
       );
 
       // Read response as text first to avoid "body stream already read" error
@@ -454,7 +460,7 @@ class HttpClient {
     } catch (error) {
       console.error(`API Request failed for ${url}:`, error);
 
-      // 更详细的错误处理
+      // 更详细的错误处���
       if (error instanceof Error) {
         if (error.name === "AbortError") {
           return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
     proxy: {
       "/api": {
-        target: "http://l4flhxbv.beesnat.com",
+        target: "http://rc56132tg24.vicp.fun",
         changeOrigin: true,
         secure: false,
         configure: (proxy, _options) => {


### PR DESCRIPTION
Updates API configuration and default behavior:

- Change default data source from "mock" to "api" mode in DataSourceContext
- Update API base URL from http://l4flhxbv.beesnat.com to http://rc56132tg24.vicp.fun across all files
- Reduce API timeout values for faster error diagnosis (health: 8s→5s, metrics: 25s→10s, default: 15s→8s)
- Add enhanced logging with emoji indicators for API requests and responses
- Improve error handling for different API response formats in getCurrentMetrics()
- Add support for nested metrics response format: {"metrics": [...]}
- Update proxy configuration in vite.config.ts to use new API endpoint

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/33b39cc81dbd4012ab494fdd00f857b0/spark-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>33b39cc81dbd4012ab494fdd00f857b0</projectId>-->
<!--<branchName>spark-home</branchName>-->